### PR TITLE
Fixed warning on repo missing on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
-  "name": "railstest",
+  "name": "drupalcores",
   "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/laurii/drupalcores.git"
+  },
   "devDependencies": {
     "del": "^0.1.3",
     "gulp": "^3.8.10",


### PR DESCRIPTION
To avoid this error on npm actions:

```
npm WARN package.json railstest@0.0.1 No repository field.
