### PR TITLE
Add not_chx mapping from upstream

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,6 @@ else
 fi
 
 ./cores.rb > ./pages/index.html
-./companies.rb > ./pages/companies.html
 ./json.rb > ./pages/data.json
 
 cd pages

--- a/cores.rb
+++ b/cores.rb
@@ -90,7 +90,7 @@ __END__
  <% contributors.each do |name, mentions| %>
  <tr>
   <td id="<%= name %>"><%= (lastMentions == mentions) ? lastOrder : i %></td>
-  <td><a href="http://dgo.to/@<%= name %>"><%= name %></a></td>
+  <td><a href="https://www.drupal.org/u/<%= name.gsub ' ', '-' %>"><%= name %></a></td>
   <td><%= mentions %></td>
   <td><%= ((mentions/sum)*100).round(4) %>%</td>
   <% if lastMentions != mentions %>

--- a/json.rb
+++ b/json.rb
@@ -7,7 +7,7 @@ require 'json'
 
 name_mappings = YAML::load_file('./name_mappings.yml')
 contributors = Hash.new(0)
-%x[git --git-dir=drupal/.git --work-tree=drupal log 8.x --since=2011-03-09 -s --format=%s].split("\n").each do |m|
+%x[git --git-dir=drupal/.git --work-tree=drupal log 8.0.x --since=2011-03-09 -s --format=%s].split("\n").each do |m|
   m.gsub(/\-/, '_').scan(/\s(?:by\s?)([[:word:]\s,.|]+):/i).each do |people|
     people[0].split(/[,|]/).each do |p|
       name = p.strip.downcase


### PR DESCRIPTION
Not that this changes a lot, but since the patch to upstream came from chx, it'd be nice to have in the new 'official' drupalcores.com

https://github.com/lauriii/drupalcores/commit/23b829d8e338c5ab51c951bac90cd51ffa3bb9e2