### PR TITLE
Use 8.2.x as the default branch

### DIFF
--- a/app/bin/json.rb
+++ b/app/bin/json.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 log_args = ARGV[0] || '--since=2011-03-09'
-git_command = 'git --git-dir=../drupalcore/.git --work-tree=drupal log 8.1.x ' + log_args + ' -s --format=%s'
+git_command = 'git --git-dir=../drupalcore/.git --work-tree=drupal log 8.2.x ' + log_args + ' -s --format=%s'
 
 Encoding.default_external = Encoding::UTF_8
 require 'erb'


### PR DESCRIPTION
According to the backport and semver policies, 8.2.x will include almost all changes in 8.1.x, but many changes in 8.2.x will not be in 8.1.x.