### PR TITLE
Credit Revert of Revert

### DIFF
--- a/app/bin/json.rb
+++ b/app/bin/json.rb
@@ -13,8 +13,8 @@ contributors = Hash.new(0)
 commits = Array.new
 reverts = Array.new
 issue_regexp = Regexp.new '#[0-9]+'
-reverts_regexp = Regexp.new '^Revert \"(?<credits>.+#[0-9]+.* by [^:]+:).*'
-reverts_regexp_loose = Regexp.new '^Revert .*(?<issue>#[0-9]+).*'
+reverts_regexp = Regexp.new '^Revert \"(?<credits>[^Revert \"].+#[0-9]+.* by [^:]+:).*'
+reverts_regexp_loose = Regexp.new '^Revert (?!\"Revert\ ).*(?<issue>#[0-9]+).*'
 
 %x[#{git_command}].split("\n").each do |c|
   if c =~ reverts_regexp then


### PR DESCRIPTION
Read next commit messages:

> Revert "Revert "Issue #2241633 by sun: Simplify site-specific service overrides."

> Revert "Revert "Issue #2457653 by Gábor Hojtsy: System.site langcode is both used as a file language code and a site language code""

> Revert "Revert "Issue #2489922 by anavarre, RavindraSingh: Fix minor typos""

> Revert "Revert "Issue #2510104 by pwolanin, nod_, Fabianx, Wim Leers, droplet, Pere Orga: Convert drupalSettings from JavaScript to JSON, to allow for CSP in the future""

> Revert "Revert "Issue #2761403 by Berdir: Move runtime theme registry into bootstrap cache""

> Revert "Revert "Issue #2834291 by claudiu.cristea, Berdir, amateescu, timmillwood, catch: Add a SQL index for entity types that are using EntityPublishedInterface""

Because the revert regexp in `json.rb`

```ruby
reverts_regexp = Regexp.new '^Revert \"(?<credits>.+#[0-9]+.* by [^:]+:).*'
reverts_regexp_loose = Regexp.new '^Revert .*(?<issue>#[0-9]+).*'
```

...these commit messages are considered reverts and are not credited. But these are valid contributions because the original commit was reverted (the contributor is not credited) and, then, the revert is reverted -- as a consequence this is the commit where the contribution gets in and the contributor should be credited.