### PR TITLE
Build stats from Drupal origin/HEAD

### DIFF
--- a/app/bin/build.sh
+++ b/app/bin/build.sh
@@ -5,12 +5,11 @@ git pull
 echo "Updating Sub Repos"
 
 if [ ! -d "./app/drupalcore" ]; then
-  git clone --branch 8.4.x http://git.drupal.org/project/drupal.git ./app/drupalcore
+  git clone http://git.drupal.org/project/drupal.git ./app/drupalcore
 else
   cd ./app/drupalcore
-  git fetch
-  git checkout 8.4.x
-  git pull
+  git remote update
+  git checkout origin/HEAD
   cd ../bin
 fi
 

--- a/app/bin/json.rb
+++ b/app/bin/json.rb
@@ -4,7 +4,7 @@ log_args = ARGV[0] || '--since=2011-03-09'
 git_command = <<-COMMANDS
 cd ../drupalcore
 git fetch
-git log 8.4.x #{log_args} -s --format=%s
+git log origin/HEAD #{log_args} -s --format=%s
 cd ../bin
 COMMANDS
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,8 +38,8 @@ gulp.task('drupalcore', function () {
   var fs = require('fs');
 
   return gulp.src('')
-    .pipe(gulpif(!fs.existsSync(paths.drupal), shell(['git clone --branch 8.4.x http://git.drupal.org/project/drupal.git ' + paths.drupal])))
-    .pipe(shell(['git pull'],{ 'ignoreErrors': true, 'cwd': './app/drupalcore'}));
+    .pipe(gulpif(!fs.existsSync(paths.drupal), shell(['git clone http://git.drupal.org/project/drupal.git ' + paths.drupal])))
+    .pipe(shell(['git remote update', 'git checkout origin/HEAD'],{ 'ignoreErrors': true, 'cwd': './app/drupalcore'}));
 });
 
 // Build contributors page


### PR DESCRIPTION
The current Drupal core development branch is 8.5.x but Drupalcores is still building the report from the 8.4.x branch.

Other PRs (#89, #96, #105) have addressed this by incrementing the branch number.  The problem is that we'll keep having to do this every 6 months, and it can be overlooked.

This PR proposes a different approach, which removes the need to keep updating the branch number every 6 months.

Instead of specifying a branch number during git operations, we can ask for `origin/HEAD` and assume that ref points to the active development branch.  The ref should point to whatever is set as the "default branch" in the Drupal project node settings (i.e. under Edit > Default branch).   I assume the core committers update this?  The default branch is currently 8.5.x.

This PR does the following:

- Removes the `--branch` flag from `git clone`.  This will result in a checkout of whichever branch is marked as `origin/HEAD` in the upstream repo on drupal.org
- Changes the current checkout-and-pull approach to `git remote update` followed by `git checkout origin/HEAD`.  This results in a detached head state; we're no longer building the stats from a local branch.
- Changes the ref for `git log` from a branch number to `origin/HEAD`