### PR TITLE
Fix Travis test failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
+  - '8'
+  - '6'
+  - '4'
 install:
   - npm install gulp -g
   - npm install


### PR DESCRIPTION
Several pull requests have Travis test failures, due to a syntax error:

```/home/travis/build/lauriii/drupalcores/node_modules/run-sequence/node_modules/chalk/index.js:2
const escapeStringRegexp = require('escape-string-regexp');
^^^^^
SyntaxError: Use of const in strict mode.
```

I found a solution at this StackOverflow answer - https://stackoverflow.com/questions/22603078/syntaxerror-use-of-const-in-strict-mode

This PR updates the version of NodeJS being used by Travis.

The change in the chalk module which caused it was https://github.com/chalk/chalk/commit/249b9ac7e75077de5fc9d8063df35918745e8471

