### PR TITLE
Add license field (MIT) to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "drupalcores",
   "version": "0.0.1",
+  "license" : "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/laurii/drupalcores.git"


### PR DESCRIPTION
`npm install` gives a warning:  `npm WARN drupalcores@0.0.1 No license field.`

This PR adds a license to package.json, and gets rid of this warning.
The repo already has an MIT license file, so it's no changing the license, just repeating it.