### PR TITLE
Ensure origin/HEAD is pointing to the correct branch

### DIFF
--- a/app/bin/build.sh
+++ b/app/bin/build.sh
@@ -9,6 +9,7 @@ if [ ! -d "./app/drupalcore" ]; then
 else
   cd ./app/drupalcore
   git remote update
+  git remote set-head origin -a
   git checkout origin/HEAD
   cd ../bin
 fi

--- a/app/bin/json.rb
+++ b/app/bin/json.rb
@@ -4,6 +4,8 @@ log_args = ARGV[0] || '--since=2011-03-09'
 git_command = <<-COMMANDS
 cd ../drupalcore
 git fetch
+git remote update
+git remote set-head origin -a
 git log origin/HEAD #{log_args} -s --format=%s
 cd ../bin
 COMMANDS

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('drupalcore', function () {
 
   return gulp.src('')
     .pipe(gulpif(!fs.existsSync(paths.drupal), shell(['git clone http://git.drupal.org/project/drupal.git ' + paths.drupal])))
-    .pipe(shell(['git remote update', 'git checkout origin/HEAD'],{ 'ignoreErrors': true, 'cwd': './app/drupalcore'}));
+    .pipe(shell(['git remote update', 'git remote set-head origin -a', 'git checkout origin/HEAD'],{ 'ignoreErrors': true, 'cwd': './app/drupalcore'}));
 });
 
 // Build contributors page


### PR DESCRIPTION
On an existing checkout origin/HEAD is not necessarily up-to-date. We need to update it in order to ensure we are pointing to the correct default remote branch. The default remote branch is updated on every Drupal 8 minor release so atm it is 8.5.x which is the probably okay to calculate from. At least it will auto-update. That said it does mean that some commits will not be counted until the 8.6.0 is released.