### PR TITLE
#119: Use the Drupal.org API to bypass user page access restrictions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.egg
 *.egg-info
 dist
+data
 build
 eggs
 parts

--- a/app/bin/companies.rb
+++ b/app/bin/companies.rb
@@ -137,6 +137,7 @@ companies.each do |k, values|
     companies_info[k] = Hash.new(0)
     companies_info[k]['title'] = values['title']
     companies_info[k]['link'] = values['link']
+    companies_info[k]['id'] = values['id']
   end
   values['contributors'].each do |name, mentions|
     company_mapping[name] = k

--- a/app/bin/countries.rb
+++ b/app/bin/countries.rb
@@ -3,20 +3,23 @@
 Encoding.default_external = Encoding::UTF_8
 require 'erb'
 require 'yaml'
-require 'nokogiri'
 require 'open_uri_redirections'
 require 'time'
+require 'net/http'
 require 'json'
 
 COMPANY_NOT_FOUND='not_found'
 COMPANY_NOT_DEFINED='not_defined'
+COMPANY_NOT_SPECIFIED='Not specified'
 UPDATE_NONE=0
 UPDATE_NOT_FOUND=1
 UPDATE_ALL=2
 
+country_names = YAML::load_file('../config/country_names.yml')
 name_variants = Hash.new(0)
-if File.exists? ('../data/company_infos.yml')
-  companies_info = YAML::load_file('../data/company_infos.yml')
+Dir.mkdir('../data') unless Dir.exist?('../data')
+if File.exists? ('../data/country_infos.yml')
+  companies_info = YAML::load_file('../data/country_infos.yml')
 else
   companies_info = Hash.new(0)
 end
@@ -44,90 +47,62 @@ data = JSON.parse(file)
 contributors = data['contributors']
 companies = Hash.new(0)
 
-def ensure_company(companies, companies_info, key, title, link)
+def ensure_company(companies, companies_info, key, title)
   unless companies.key? key
     companies[key] = Hash.new(0)
     companies[key]['contributors'] = Hash.new(0)
     if companies_info.key? key
       companies[key]['title'] = companies_info[key]['title']
-      companies[key]['link'] = companies_info[key]['link']
     else
       companies[key]['title'] = title
-      companies[key]['link'] = link
     end
   end
 end
 
 contributors.sort_by {|k, v| v }.reverse.each do |name,mentions|
-  next if name == 'Not specified'
+  next if name == COMPANY_NOT_SPECIFIED
 
   if company_mapping.key? name
     if update == UPDATE_NONE or (update == UPDATE_NOT_FOUND and company_mapping[name] != COMPANY_NOT_FOUND)
-      ensure_company(companies, companies_info, company_mapping[name], 'should be filled via company infos', 'should be filled via company infos')
+      ensure_company(companies, companies_info, company_mapping[name], country_names[company_mapping[name].upcase])
       companies[company_mapping[name]]['mentions'] += mentions
       companies[company_mapping[name]]['contributors'][name] = mentions
       next
     end
   end
   if name_variants.key? name
-    urlname = name_variants[name].gsub ' ', '-';
+    urlname = name_variants[name]
   else
-    urlname = name.gsub ' ', '-';
+    urlname = name
   end
-  url = "https://www.drupal.org/u/#{urlname}"
-  url = URI::encode(url)
+  url = URI::encode("https://www.drupal.org/api-d7/user.json?name=#{urlname}")
+  uri = URI(url)
   begin
-    html = open(url, :allow_redirections => :safe)
-    doc = Nokogiri::HTML(html)
+    response = Net::HTTP.get(uri)
+    user = JSON.parse(response)
   rescue
     next
   end
-  found = true
-  doc.css('title').each do |title|
-    if title.text == 'Page not found | Drupal.org'
-      found = false
-    end
+  found = false
+  if user['list'].count > 0
+    found = true
   end
   unless found
-    ensure_company(companies, companies_info, COMPANY_NOT_FOUND, 'Users not found', 'Users not found')
+    ensure_company(companies, companies_info, COMPANY_NOT_FOUND, 'Users not found')
     companies[COMPANY_NOT_FOUND]['mentions'] += mentions
     companies[COMPANY_NOT_FOUND]['contributors'][name] = mentions
-  end
-  if found
-    found = false
-    if company_wrapper = doc.at_css('.field-name-field-country')
-      if company_wrapper.at_css('img')
-        company = company_wrapper.at_css('img')['alt']
-      else
-        company = company_wrapper.text
-      end
-      if company_wrapper.at_css('a')
-        link = company_wrapper.at_css('a')
-        link['href'] = 'https://drupal.org' + link['href']
-        # If we still don't have the company name, follow the link to the page.
-        unless company
-          html = open(link['href'], :allow_redirections => :safe)
-          company_page = Nokogiri::HTML(html)
-          if company_title  = company_page.at_css('#page-subtitle')
-            company = company_title.text
-          end
-        end
-      else
-        # If there is no link, use the company name instead.
-        link = company
-      end
-      company = company.strip
-      company_key = company.downcase
-      ensure_company(companies, companies_info, company_key, company, link.to_s)
-      companies[company_key]['mentions'] += mentions
-      companies[company_key]['contributors'][name] = mentions
-      found = true
+  else
+    company = user['list'][0]['field_country']
+    if company.nil?
+      company = COMPANY_NOT_SPECIFIED
+      title = company
+    else
+      title = country_names[company]
     end
-    unless found
-      ensure_company(companies, companies_info, COMPANY_NOT_DEFINED, 'Not specified', 'Not specified')
-      companies[COMPANY_NOT_DEFINED]['mentions'] += mentions
-      companies[COMPANY_NOT_DEFINED]['contributors'][name] = mentions
-    end
+    company_key = company.downcase
+    ensure_company(companies, companies_info, company_key, title)
+    companies[company_key]['mentions'] += mentions
+    companies[company_key]['contributors'][name] = mentions
   end
 end
 
@@ -136,7 +111,6 @@ companies.each do |k, values|
   unless companies_info.key? k
     companies_info[k] = Hash.new(0)
     companies_info[k]['title'] = values['title']
-    companies_info[k]['link'] = values['link']
   end
   values['contributors'].each do |name, mentions|
     company_mapping[name] = k
@@ -145,7 +119,7 @@ companies.each do |k, values|
     companies_info.delete(k)
   end
 end
-File.open('../data/company_infos.yml', 'w') { |f| YAML.dump(companies_info, f) }
+File.open('../data/country_infos.yml', 'w') { |f| YAML.dump(companies_info, f) }
 File.open('../data/country_mapping.yml', 'w') { |f| YAML.dump(company_mapping, f) }
 
 sum = contributors.values.reduce(:+).to_f

--- a/app/bin/json.rb
+++ b/app/bin/json.rb
@@ -48,10 +48,10 @@ commits.to_enum.with_index.reverse_each do |c, i|
 end
 
 commits.each do |m|
-  m.gsub(/\-/, '_').scan(/\s(?:by\s?)([[:word:]\s,.@|]+):/i).each do |people|
-    people[0].split(/(?:,|\||\band\b|\bet al(?:.)?)/).each do |p|
-      name = p.strip.downcase
-      contributors[name_mappings[name] || name] += 1 unless p.nil?
+  m.scan(/\s(?:by\s?)([[:word:]\s,.@|\-]+):[^:]/i).each do |people|
+    people[0].split(/(?:,|\||\band\b|\bfollow[-]?up(?:\sby)?\b|\bet al(?:.)?)/).compact.reject(&:empty?).each do |p|
+      name = p.strip
+      contributors[name_mappings[name.downcase] || name] += 1 unless p.nil?
     end
   end
 end

--- a/app/config/country_names.yml
+++ b/app/config/country_names.yml
@@ -1,0 +1,252 @@
+AF: Afghanistan
+AX: Åland Islands
+AL: Albania
+DZ: Algeria
+AS: American Samoa
+AD: Andorra
+AO: Angola
+AI: Anguilla
+AQ: Antarctica
+AG: Antigua and Barbuda
+AR: Argentina
+AM: Armenia
+AW: Aruba
+AU: Australia
+AT: Austria
+AZ: Azerbaijan
+BS: Bahamas
+BH: Bahrain
+BD: Bangladesh
+BB: Barbados
+BY: Belarus
+BE: Belgium
+BZ: Belize
+BJ: Benin
+BM: Bermuda
+BT: Bhutan
+BO: Bolivia
+BA: Bosnia and Herzegovina
+BW: Botswana
+BV: Bouvet Island
+BR: Brazil
+IO: British Indian Ocean Territory
+VG: British Virgin Islands
+BN: Brunei
+BG: Bulgaria
+BF: Burkina Faso
+BI: Burundi
+KH: Cambodia
+CM: Cameroon
+CA: Canada
+CV: Cape Verde
+BQ: Caribbean Netherlands
+KY: Cayman Islands
+CF: Central African Republic
+TD: Chad
+CL: Chile
+CN: China
+CX: Christmas Island
+CC: Cocos (Keeling) Islands
+CO: Colombia
+KM: Comoros
+CG: Republic of the Congo
+CD: DR of the Congo
+CK: Cook Islands
+CR: Costa Rica
+HR: Croatia
+CU: Cuba
+CW: Curaçao
+CY: Cyprus
+CZ: Czech Republic
+DK: Denmark
+DJ: Djibouti
+DO: Dominican Republic
+DM: Dominica
+EC: Ecuador
+EG: Egypt
+SV: El Salvador
+GQ: Equatorial Guinea
+ER: Eritrea
+EE: Estonia
+ET: Ethiopia
+FK: Falkland Islands
+FO: Faroe Islands
+FJ: Fiji
+FI: Finland
+FR: France
+GF: French Guiana
+PF: French Polynesia
+TF: French Southern Territories
+GA: Gabon
+GM: The Gambia
+GE: Georgia
+DE: Germany
+GH: Ghana
+GI: Gibraltar
+GR: Greece
+GL: Greenland
+GD: Grenada
+GP: Guadeloupe
+GU: Guam
+GT: Guatemala
+GG: Guernsey
+GW: Guinea-Bissau
+GN: Guinea
+GY: Guyana
+HT: Haiti
+HM: Heard Island and McDonald Islands
+HN: Honduras
+HK: Hong Kong
+HU: Hungary
+IS: Iceland
+IN: India
+ID: Indonesia
+IR: Iran
+IQ: Iraq
+IE: Ireland
+IM: Isle of Man
+IL: Israel
+IT: Italy
+CI: Ivory Coast
+JM: Jamaica
+JP: Japan
+JE: Jersey
+JO: Jordan
+KZ: Kazakhstan
+KE: Kenya
+KI: Kiribati
+XK: Kosovo
+KW: Kuwait
+KG: Kyrgyzstan
+LA: Laos
+LV: Latvia
+LB: Lebanon
+LS: Lesotho
+LR: Liberia
+LY: Libya
+LI: Liechtenstein
+LT: Lithuania
+LU: Luxembourg
+MO: Macau
+MK: Macedonia
+MG: Madagascar
+MW: Malawi
+MY: Malaysia
+MV: Maldives
+ML: Mali
+MT: Malta
+MH: Marshall Islands
+MQ: Martinique
+MR: Mauritania
+MU: Mauritius
+YT: Mayotte
+MX: Mexico
+FM: Micronesia
+MD: Moldova
+MC: Monaco
+MN: Mongolia
+ME: Montenegro
+MS: Montserrat
+MA: Morocco
+MZ: Mozambique
+MM: Myanmar
+NA: Namibia
+NR: Nauru
+NP: Nepal
+AN: Netherlands Antilles
+NL: Netherlands
+NC: New Caledonia
+NZ: New Zealand
+NI: Nicaragua
+NG: Nigeria
+NE: Niger
+NU: Niue
+NF: Norfolk Island
+KP: North Korea
+MP: Northern Mariana Islands
+'NO': Norway
+OM: Oman
+PK: Pakistan
+PW: Palau
+PS: Palestine
+PA: Panama
+PG: Papua New Guinea
+PY: Paraguay
+PE: Peru
+PH: Philippines
+PN: Pitcairn
+PL: Poland
+PT: Portugal
+PR: Puerto Rico
+QA: Qatar
+RE: Réunion
+RO: Romania
+RU: Russia
+RW: Rwanda
+BL: Saint Barthélemy
+SH: Saint Helena
+KN: Saint Kitts and Nevis
+LC: Saint Lucia
+MF: Saint Martin (French)
+PM: Saint Pierre and Miquelon
+VC: Saint Vincent and the Grenadines
+WS: Samoa
+SM: San Marino
+ST: São Tomé and Príncipe
+SA: Saudi Arabia
+SN: Senegal
+RS: Serbia
+SC: Seychelles
+SL: Sierra Leone
+SG: Singapore
+SX: Sint Maarten (Dutch)
+SK: Slovakia
+SI: Slovenia
+SB: Solomon Islands
+SO: Somalia
+ZA: South Africa
+GS: South Georgia and the South Sandwich Islands
+KR: South Korea
+SS: South Sudan
+ES: Spain
+LK: Sri Lanka
+SD: Sudan
+SR: Suriname
+SJ: Svalbard and Jan Mayen
+SZ: Swaziland
+SE: Sweden
+CH: Switzerland
+SY: Syria
+TW: Taiwan
+TJ: Tajikistan
+TZ: Tanzania
+TH: Thailand
+TL: Timor-Leste
+TG: Togo
+TK: Tokelau
+TO: Tonga
+TT: Trinidad and Tobago
+TN: Tunisia
+TR: Turkey
+TM: Turkmenistan
+TC: Turks and Caicos Islands
+TV: Tuvalu
+VI: U.S. Virgin Islands
+UG: Uganda
+UA: Ukraine
+AE: United Arab Emirates
+GB: United Kingdom
+UM: United States Minor Outlying Islands
+US: United States
+UY: Uruguay
+UZ: Uzbekistan
+VU: Vanuatu
+VA: Vatican
+VE: Venezuela
+VN: Vietnam
+WF: Wallis and Futuna Islands
+EH: Western Sahara
+YE: Yemen
+YU: Yugoslavia
+ZM: Zambia
+ZW: Zimbabwe

--- a/app/config/name_mappings.yml
+++ b/app/config/name_mappings.yml
@@ -1,49 +1,55 @@
-dereine: dawehner
-dereine et al: dawehner
-rob loach: robloach
-david rothstein: david_rothstein
-davereid: dave reid
-niklas: niklas fiekas
-rootatwc: parisliakos
-tim.plunkett et al: tim.plunkett
-tim.plunket: tim.plunkett
-ianmthomasuk: ianthomas_uk
-jessebeach et al: jessebeach
-aspilicious et al: aspilicious
-andypost et al: andypost
-neclimdul et al: neclimdul
-sun et al: sun
-droplet et al: droplet
-podarok et al: podarok
-damien tournoud et al: damien tournoud
-and damien tournoud: damien tournoud
-damz: damien tournoud
-mrfelton. et al: mrfelton
-jasonrsavino et al: jasonrsavino
-marcp et all: marcp
-fubhy the cat: fubhy
-jeroen12345: jeroent
-no_commit_credit: xjm
-joelpitett: joelpittet
-lewis nyman: lewisnyman
-lewisnyman bartik: lewisnyman
-emma_maria: emma.maria
-long wave: longwave
-follow up yched: yched
 _nod: nod_
-nod: nod_
-moshe weitzmann: moshe weitzman
-javier.alejandr...: javier.alejandro.castro
-markcarver: mark carver
-dominique clause: dom.
-juampy: juampynr
-not_chx: Not specified
+and damien tournoud: Damien Tournoud
+berdir: Berdir
+bleen18: bleen
+cam8001: Cameron Tod
 chx: Not specified
+damz: Damien Tournoud
+dan reinders: SpartyDan
+davereid: Dave Reid
+david rothstein: David_Rothstein
 davinder.snehi: snehi
-nguerrero: nesta_
-juanmamr: jmmarquez
-gnugeti: gnuget
-shashi1028: shashikant_chauhan
+dereine: dawehner
 developermitesh: miteshmap
+dmitrydrozdik: ddrozdik
+dominique clause: Dom.
+ellatheharpy: shnark
+emma_maria: emma.maria
+floydm: floydm
+follow up yched: yched
+fubhy the cat: fubhy
+gnugeti: gnuget
+hardik.p: hardikpandya
+heyrocker: gdd
+ianmthomasuk: ianthomas_uk
+janstoeckler: jan.stoeckler
+javier.alejandr...: Not specified
+jcventura: jcnventura
+jeroen12345: JeroenT
+joelpitett: joelpittet
+juampy: juampynr
+juanmamr: jmmarquez
+lewis nyman: LewisNyman
+lewisnyman: LewisNyman
+lewisnyman bartik: LewisNyman
+lokeoke: l0ke
+long wave: longwave
+malavya: imalabya
+mark carver: markcarver
 mark conroy: markconroy
+moshe weitzmann: moshe weitzman
+nguerrero: nesta_
+niklas: Niklas Fiekas
+no_commit_credit: xjm
+nod: nod_
+not_chx: Not specified
+rhm50: rhm5000
+rob loach: RobLoach
+rocket_nova: drupal_was_my_past
+rootatwc: ParisLiakos
+sivaji@knackforge.com: Sivaji
+shashi1028: shashikant_chauhan
+smiro: smira
+tim.plunket: tim.plunkett
+typhonius: adammalone
 yogesh pawar: yogeshmpawar

--- a/app/templates/companies.html.erb
+++ b/app/templates/companies.html.erb
@@ -3,8 +3,9 @@
       <section class="main-content inner">
         <div class="table-filter">
           <ul>
-          <li>The exposed data only takes into account the company name that contributors have listed
-          in their drupal.org profile at the time the list was curated. It may not be an accurate
+          <li>The exposed data only takes into account the company name that contributors have set as current
+          in their drupal.org profile at the time the list was curated. Only the first company marked as
+          current will be used, with the order being determined by drupal.org. It may not be an accurate
           representation of the company that actually sponsored their contribution.</li>
           <li>This list only reflects commit mentions by individuals. Not every commit mention is a valuable
           as others. Is just a metric, so be careful when interpreting it.</li>
@@ -36,7 +37,7 @@
  </tr>
  <% companies.each do |name, values| %>
  <tr id="<%= name %>">
-  <td id="<%= name %>"><%= (lastMentions == values['mentions']) ? lastOrder : i %></td>
+  <td><%= (lastMentions == values['mentions']) ? lastOrder : i %></td>
   <td><%= values['link'] %> <img src="images/icon_info.png" alt="Info" title="Toggle employees" class="toggle">
     <table class="employees" style="display: none">
       <% values['contributors'].each do |contributor, mentions| %>

--- a/app/templates/countries.html.erb
+++ b/app/templates/countries.html.erb
@@ -27,7 +27,7 @@
  <% companies.each do |name, values| %>
  <tr id="<%= name %>">
   <td id="<%= name %>"><%= (lastMentions == values['mentions']) ? lastOrder : i %></td>
-  <td><%= values['link'] %> <img src="images/icon_info.png" alt="Info" title="Toggle employees" class="toggle">
+  <td><%= values['title'] %> <img src="images/icon_info.png" alt="Info" title="Toggle employees" class="toggle">
     <table class="employees" style="display: none">
       <% values['contributors'].each do |contributor, mentions| %>
       <tr>

--- a/app/templates/countries.html.erb
+++ b/app/templates/countries.html.erb
@@ -26,7 +26,7 @@
  </tr>
  <% companies.each do |name, values| %>
  <tr id="<%= name %>">
-  <td id="<%= name %>"><%= (lastMentions == values['mentions']) ? lastOrder : i %></td>
+  <td><%= (lastMentions == values['mentions']) ? lastOrder : i %></td>
   <td><%= values['title'] %> <img src="images/icon_info.png" alt="Info" title="Toggle employees" class="toggle">
     <table class="employees" style="display: none">
       <% values['contributors'].each do |contributor, mentions| %>

--- a/app/templates/index.html.erb
+++ b/app/templates/index.html.erb
@@ -27,7 +27,7 @@
  <% notSpecified = (name === 'Not specified') %>
  <tr id="<%= name %>">
   <td><%= (lastMentions == mentions) ? lastOrder : i %></td>
-  <td><% if !notSpecified %><a href="https://www.drupal.org/u/<%= name.gsub ' ', '-' %>"><%= name %></a><% else %><%= name %><% end %>
+  <td><% if !notSpecified %><a href="https://www.drupal.org/u/<%= name.downcase.gsub ' ', '-' %>"><%= name %></a><% else %><%= name %><% end %>
   </td>
   <td><% if !notSpecified %><a href="http://cgit.drupalcode.org/drupal/log/?qt=grep&q=<%= name.gsub ' ', '+' %>"><%= mentions %></a><% else %><%= mentions %><% end %></td>
   <td><%= ((mentions/sum)*100).round(4) %>%</td>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "drupalcores",
   "version": "0.0.1",
-  "license" : "MIT",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/laurii/drupalcores.git"


### PR DESCRIPTION
This fixes #119.

It's a major rewrite of the companies.rb and countries.rb.

The json.rb no longer lowercases the contributor names (nor replace - with _), but the name mapping still uses lowercased keys. Because d.o user URLs are not case-sensitive, I've kept those lowercase. I've also adapted the commit message parser to accept '-' in usernames and to reduce some false positives when using 'by' somewhere in commit description followed by a class::method.

Finally, I added a mapping between 2-letter country codes and English names, using as source the d.o user edit form. This is needed because the user.json response only specifies the 2-letter code. Norway had some problems as for some reason the hash key gets saved as >'no'< and not simply >no<.