### PR TITLE
Change name mapping of chx from not specified to charlie-chx-negyesi

### DIFF
--- a/app/config/name_mappings.yml
+++ b/app/config/name_mappings.yml
@@ -3,7 +3,6 @@ and damien tournoud: Damien Tournoud
 berdir: Berdir
 bleen18: bleen
 cam8001: Cameron Tod
-chx: charlie-chx-negyesi
 damz: Damien Tournoud
 dan reinders: SpartyDan
 davereid: Dave Reid
@@ -42,7 +41,6 @@ nguerrero: nesta_
 niklas: Niklas Fiekas
 no_commit_credit: xjm
 nod: nod_
-not_chx: charlie-chx-negyesi
 rhm50: rhm5000
 rob loach: RobLoach
 rocket_nova: drupal_was_my_past

--- a/app/config/name_mappings.yml
+++ b/app/config/name_mappings.yml
@@ -3,7 +3,7 @@ and damien tournoud: Damien Tournoud
 berdir: Berdir
 bleen18: bleen
 cam8001: Cameron Tod
-chx: Not specified
+chx: charlie-chx-negyesi
 damz: Damien Tournoud
 dan reinders: SpartyDan
 davereid: Dave Reid
@@ -42,7 +42,7 @@ nguerrero: nesta_
 niklas: Niklas Fiekas
 no_commit_credit: xjm
 nod: nod_
-not_chx: Not specified
+not_chx: charlie-chx-negyesi
 rhm50: rhm5000
 rob loach: RobLoach
 rocket_nova: drupal_was_my_past


### PR DESCRIPTION
The old accounts of Charlie Negyesi are now mapped to "Not specified". I think this not OK. Charlie is a member of the Drupal community and should be treated with the same minimum level of respect as any other member of our community. @lauriii: You are a core committer of the Drupal project, that is a very high leadership position in our community. Could you treat Charlie with the respect that every member of our community deserves. Thanks.